### PR TITLE
Update Extension.php

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -35,7 +35,7 @@ class Extension extends BaseExtension
         $this->addTwigFunction('setlanguage', 'twigSetLanguage');
         $this->addTwigFunction('setLanguage', 'twigSetLanguage'); # Deprecated! This was the old twig function.
 
-        $root = $this->app['resources']->getUrl('bolt');
+        $root = $this->app['config']->get('general/branding/path') . '/';
 
         // Admin menu
         $this->addMenuOption('Label translations', $root . 'labels', 'fa:flag');


### PR DESCRIPTION
as
$root = $this->app['resources']->getUrl('bolt');
outputs "/subfolder/branding/" and creates a "No route found for" error when bolt is not installed inside root folder
$root = $this->app['config']->get('general/branding/path') . '/';
outputs "/branding/" and fixes the routing issue when bolt is installed in a subfolder.
