### PR TITLE
Check if session is started before setting to it

### DIFF
--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -132,7 +132,10 @@ class LabelsExtension extends SimpleExtension
             $lang = $config['default'];
         }
 
-        $app['session']->set('lang', $lang);
+        if($app['session']->isStarted()){
+            $app['session']->set('lang', $lang);
+        }
+
         $this->setCurrentLanguage($lang);
     }
 


### PR DESCRIPTION
This fixes an issue where the labels extension would always try to start a session,
