### PR TITLE
Actually check the show_menu option

### DIFF
--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -81,6 +81,12 @@ class LabelsExtension extends SimpleExtension
      */
     protected function registerMenuEntries()
     {
+        $app = $this->getContainer();
+
+        if (!$app['labels.config']->isShowMenu()) {
+            return [];
+        }
+
         return [
             (new MenuEntry('labels', 'labels'))
                 ->setLabel('Label translations')


### PR DESCRIPTION
Or we could remove it ¯\\\_(ツ)\_/¯