### PR TITLE
On page exit confirm dialog when edited labels are not saved

### DIFF
--- a/templates/import_form.twig
+++ b/templates/import_form.twig
@@ -84,13 +84,7 @@ jQuery(document).ready(function($) {
     // If we haven't been passed the event get the window.event
     e = e || window.event;
 
-    var message = 'Any text will block the navigation and display a prompt';
-
-    // For IE6-8 and Firefox prior to version 4
-    if (e) 
-    {
-        e.returnValue = message;
-    }
+    var message = 'This page is asking you to confirm that you want to leave - data you have entered may not be saved.';
 
     // For Chrome, Safari, IE8+ and Opera 12+
     return message;

--- a/templates/import_form.twig
+++ b/templates/import_form.twig
@@ -15,7 +15,7 @@
 
 {% block page_main %}
 
-<form action="{{ path('save_labels') }}" method="POST" enctype="multipart/form-data">
+<form id="labels-form" action="{{ path('save_labels') }}" method="POST" enctype="multipart/form-data">
 
     <button class="btn btn-primary" disabled="disabled" id="save-button" type="submit">
         <i class='fa fa-save'></i> Save

--- a/templates/import_form.twig
+++ b/templates/import_form.twig
@@ -69,6 +69,33 @@ jQuery(document).ready(function($) {
         }
     }
 
+    // Enables the confirm dialog when labels have been modified 
+    $('#labels-form').on('change', function(){
+        window.onbeforeunload = confirmOnPageExit;
+    });
+
+    // Disables the confirm dialog when saving the changes
+    $('#save-button, #save-button-bottom').click(function(){
+        window.onbeforeunload = null;
+    }); 
+
+    var confirmOnPageExit = function (e) 
+    {
+    // If we haven't been passed the event get the window.event
+    e = e || window.event;
+
+    var message = 'Any text will block the navigation and display a prompt';
+
+    // For IE6-8 and Firefox prior to version 4
+    if (e) 
+    {
+        e.returnValue = message;
+    }
+
+    // For Chrome, Safari, IE8+ and Opera 12+
+    return message;
+    };
+
 });
 </script>
 


### PR DESCRIPTION
Hi @bobdenotter,

After some troubles with Composer I managed to implement the Leave or Stay confirm dialog.

I thought it might be handy to add this to the extension since it happened to me once that I edited some labels and forgot to save them before leaving the page and then everything was lost hehe.
