### PR TITLE
Two performance improvements for fetching labels and 'current language'.

### DIFF
--- a/src/Labels.php
+++ b/src/Labels.php
@@ -20,6 +20,8 @@ class Labels
     private $filesystemManager;
     /** @var string */
     private $extBasePath;
+    /** @var array */
+    private $loadedlabels = [];
 
     /**
      * Constructor.
@@ -42,7 +44,9 @@ class Labels
      */
     public function getLabels()
     {
-        $labels = [];
+        if (!empty($this->loadedlabels)) {
+            return $this->loadedlabels;
+        }
 
         // Check that the user's JSON file exists, else copy in the default
         if (!$this->filesystemManager->has('config://extensions/labels.json')) {
@@ -81,7 +85,7 @@ class Labels
 
             /** @var \Bolt\Filesystem\Handler\File $file */
             foreach ($finder->files() as $file) {
-                $labels = json_decode($file->read(), true);
+                $this->loadedlabels = json_decode($file->read(), true);
                 continue;
             }
         } catch (\Exception $e) {
@@ -91,7 +95,7 @@ class Labels
             );
         }
 
-        return $labels;
+        return $this->loadedlabels;
     }
 
     /**

--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class LabelsExtension extends SimpleExtension
 {
+    /** @var string */
+    private $currentlanguage = null;
     protected function registerServices(Application $app)
     {
         $app['labels'] = $app->share(
@@ -259,6 +261,7 @@ class LabelsExtension extends SimpleExtension
     private function setCurrentLanguage($lang)
     {
         if ($this->isValidLanguage($lang)) {
+            $this->currentlanguage = $lang;
             $app = $this->getContainer();
             $app['twig']->addGlobal('lang', $lang);
         }
@@ -271,12 +274,19 @@ class LabelsExtension extends SimpleExtension
      */
     private function getCurrentLanguage()
     {
-        $app = $this->getContainer();
-        $twigGlobals = $app['twig']->getGlobals();
-        if (isset($twigGlobals['lang'])) {
-            return $twigGlobals['lang'];
+        if (!empty($this->currentlanguage)) {
+            $lang = $this->currentlanguage;
         } else {
-            return null;
+            $app = $this->getContainer();
+            $twigGlobals = $app['twig']->getGlobals();
+            if (isset($twigGlobals['lang'])) {
+                $lang = $twigGlobals['lang'];
+            } else {
+                $lang = null;
+            }
+            $this->currentlanguage = $lang;
         }
+
+        return $lang;
     }
 }

--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -17,6 +17,7 @@ class LabelsExtension extends SimpleExtension
 {
     /** @var string */
     private $currentlanguage = null;
+
     protected function registerServices(Application $app)
     {
         $app['labels'] = $app->share(


### PR DESCRIPTION
On a specific development site for us, this reduced the overall processing time for a page about 500%. The overhead of `{{ l('') }}` was reduced to about 1% of the previous overhead (4500 msec to 45msec).