### PR TITLE
Don't mark languages in current locale

### DIFF
--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -168,17 +168,23 @@ class LabelsExtension extends SimpleExtension
         $app = $this->getContainer();
         $label = $app['labels']->cleanLabel($label);
 
+        // Clean language codes
+        $lang = mb_strtolower($lang);
+        $defaultLang = mb_strtolower($app['labels.config']->getDefault());
+
         if (!$this->isValidLanguage($lang)) {
             $lang = $this->getCurrentLanguage();
         }
 
+
         $labels = $app['labels']->getLabels();
-        if (!empty($labels[$label][mb_strtolower($lang)])) {
-            $res = $labels[$label][mb_strtolower($lang)];
+        if (!empty($labels[$label][$lang])) {
+            $res = $labels[$label][$lang];
         } else {
             $app = $this->getContainer();
             // Only show marked labels for logged in users
-            if ($app['users']->getCurrentUser()) {
+            // And if the language is not the default lang
+            if ($app['users']->getCurrentUser() && $lang != $defaultLang ) {
                 $res = '<mark>' . $label . '</mark>';
             } else {
                 $res = $label;


### PR DESCRIPTION
In my installation all the labels got wrapped in a `<mark>`, even though I was viewing them in the default locale (which means the translations are in fact the strings in the code).

What I've done:
- Grab the default lang
- Added a check to see if the label is not found && if it we're not viewing in the default language.

It worked in my case, but might be wise for someone that knows the plug-in better to check if i'm on the right track with this pr
 