### PR TITLE
Provide `"UTF-8"` `charset` argument to `Twig\Markup` in order to prevent warning

### DIFF
--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -200,7 +200,7 @@ class LabelsExtension extends SimpleExtension
 
         // Show marked labels for logged in users
         if ($app['users']->getCurrentUser()) {
-            return new Markup('<mark>' . $label . '</mark>');
+            return new Markup('<mark>' . $label . '</mark>', 'UTF-8');
         }
 
         return new Markup($label, 'UTF-8');


### PR DESCRIPTION
Fix for when you run on `strict_variables` on a clean Bolt install without any labels. Bolt 3.4-beta5 btw, but shouldn't really matter. 

```
Uncaught Exception: Twig_Error_Runtime .

Twig_Error_Runtime in Template.php line 447: 
An exception has been thrown during the rendering of a template ("Warning: Missing argument 2 for Twig_Markup::__construct(), called in /path/to/my/bolt/extensions/vendor/bolt/labels/src/LabelsExtension.php on line 203 and defined") in "layouts/master.twig" at line 51.
```