### PR TITLE
Fix marked labels

### DIFF
--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -200,7 +200,7 @@ class LabelsExtension extends SimpleExtension
 
         // Show marked labels for logged in users
         if ($app['users']->getCurrentUser()) {
-            return new Markup('<mark>' . $label . '</mark>');
+            return new Markup('<mark>' . $label . '</mark>', 'UTF-8');
         }
 
         return new Markup($label, 'UTF-8');

--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -182,7 +182,7 @@ class LabelsExtension extends SimpleExtension
         $savedLabel = $savedLabels->getPath("$label/$lang");
 
         // If we've got a live one, send it packing!
-        if ($savedLabel !== null) {
+        if (!empty($savedLabel)) {
             return new Markup($savedLabel, 'UTF-8');
         }
 
@@ -194,7 +194,7 @@ class LabelsExtension extends SimpleExtension
         // Use the fallback if configured & exists
         $defaultLang = mb_strtolower($config->getDefault());
         $savedDefault = $savedLabels->getPath("$label/$defaultLang");
-        if ($config->isUseFallback() && $savedDefault !== null) {
+        if ($config->isUseFallback() && !empty($savedDefault)) {
             $label = $savedDefault;
         }
 


### PR DESCRIPTION
I didn't get to see them labels `<mark>`ed anymore.

I'm not sure if it is intended that way, since the result of `savedLabel` is always going to be `""` (empty string) once it's added to the JSON.

So: on the first "flash" you can see them `<mark>`ed, because it is `null` at that moment, then after a refresh it is added to the JSON, it returns `""` (I believe).

Note: this pull includes #57