### PR TITLE
Set the right language on $lang variable

### DIFF
--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -173,7 +173,7 @@ class LabelsExtension extends SimpleExtension
         /** @var Labels $labels */
         $labels = $app['labels'];
         $label = $labels->cleanLabel($label);
-        $lang = mb_strtolower($lang);
+        $lang = mb_strtolower($lang) ?: $this->getCurrentLanguage() ?: mb_strtolower($config->getDefault());
 
         if (!$this->isValidLanguage($lang)) {
             $lang = $this->getCurrentLanguage();

--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -173,11 +173,8 @@ class LabelsExtension extends SimpleExtension
         /** @var Labels $labels */
         $labels = $app['labels'];
         $label = $labels->cleanLabel($label);
-        $lang = mb_strtolower($lang) ?: $this->getCurrentLanguage() ?: mb_strtolower($config->getDefault());
+        $lang = $this->isValidLanguage($lang) ? mb_strtolower($lang) : $this->getCurrentLanguage();
 
-        if (!$this->isValidLanguage($lang)) {
-            $lang = $this->getCurrentLanguage();
-        }
         $savedLabels = $labels->getLabels();
         $savedLabel = $savedLabels->getPath("$label/$lang");
 
@@ -187,7 +184,7 @@ class LabelsExtension extends SimpleExtension
         }
 
         // If we're automatically saving new/missing labels, add it to the JSON file
-        if ($config->isAddMissing() && !$savedLabels->hasItem($label)) {
+        if ($config->isAddMissing() && $this->isValidLanguage($lang) && !$savedLabels->hasItem($label)) {
             $labels->addLabel($label);
         }
 


### PR DESCRIPTION
In `twigL($label, $lang = false)` `$lang` default value is `false`. 

If no `lang` value has been passed when calling `{{ l("label-name") }}` then try to fallback to the current language or if no current language is set then fallback to the default language set in the 'labels.config.yml' file. 

This is important when this line  https://github.com/bolt/labels/blob/master/src/LabelsExtension.php#L182 gets executed. 

`$savedLabel` won't get the right value if `$lang` variable is not a language. Which might try to add a label when it already exists.

This fixes the issue where labels are removed from `labels.json` when accessing a 404 error page.