### PR TITLE
Check MutableBag with has() instead of hasItem()

### DIFF
--- a/src/Labels.php
+++ b/src/Labels.php
@@ -114,7 +114,7 @@ class Labels
         }
 
         $jsonArray = MutableBag::from($jsonArray);
-        if ($jsonArray->hasItem($label)) {
+        if ($jsonArray->has($label)) {
             // Quietly shake our head at whomever called us, and exit silently … To the pub!
             return;
         }


### PR DESCRIPTION
Fixes #61 

It seems hasItem($label) always returns false and the check on line 117 https://github.com/BoltTranslate/labels/blob/master/src/Labels.php#L117 never evaluates to true.

Then translated labels are being reset on line 121 https://github.com/BoltTranslate/labels/blob/master/src/Labels.php#L121

