### PR TITLE
fix missing leading uppercase letter in translate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ It is recommended to use this extension in combination with the
 View the full documentation online: [Labels docs][docs].
 
 [docs]: https://bolttranslate.github.io/labels
-[translate]: https://bolttranslate.github.io/translate
+[translate]: https://bolttranslate.github.io/Translate


### PR DESCRIPTION
previous link was redirecting to a 404... 
https://bolttranslate.github.io/translate => 404
https://bolttranslate.github.io/Translate => 200