### PR TITLE
Fix removal of all translations in case of an empty translation

### DIFF
--- a/src/Labels.php
+++ b/src/Labels.php
@@ -114,7 +114,7 @@ class Labels
         }
 
         $jsonArray = MutableBag::from($jsonArray);
-        if ($jsonArray->hasItem($label)) {
+        if ($jsonArray->has($label)) {
             // Quietly shake our head at whomever called us, and exit silently … To the pub!
             return;
         }

--- a/src/LabelsExtension.php
+++ b/src/LabelsExtension.php
@@ -184,7 +184,7 @@ class LabelsExtension extends SimpleExtension
         }
 
         // If we're automatically saving new/missing labels, add it to the JSON file
-        if ($config->isAddMissing() && $this->isValidLanguage($lang) && !$savedLabels->hasItem($label)) {
+        if ($config->isAddMissing() && $this->isValidLanguage($lang) && !$savedLabels->has($label)) {
             $labels->addLabel($label);
         }
 


### PR DESCRIPTION
This is an addendum to #62 + rebased with current upstream. See original PR for explanation.